### PR TITLE
add CoCoOp approach

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ from utils import save_checkpoint
 from utils import make_classification_strings
 from utils import make_optimizer
 
-from utils.training_methods import train_clip_base, train_clip_coop
-from utils.evaluation_methods import accuracy_clip_base, accuracy_clip_coop
+from utils.training_methods import train_clip_base, train_clip_coop, train_clip_cocoop
+from utils.evaluation_methods import accuracy_clip_base, accuracy_clip_coop, accuracy_clip_cocoop
 
 from utils import convert_models_to_fp32, convert_back_to_fp16
 
@@ -72,7 +72,7 @@ def main(args):
     elif args.method == 'coop':
         trainer, validator = train_clip_coop, accuracy_clip_coop
     elif args.method == 'cocoop':
-        assert False, "Not implemented: cocoop trainer, validator in main.py"
+        trainer, validator = train_clip_cocoop, accuracy_clip_cocoop
     else:
         assert False, f"Not implemented: the method '{args.method}' is not yet implemented in main.py"
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -13,13 +13,13 @@ def save_checkpoint(args, model, epoch):
         os.makedirs(args.checkpoint_dir)
 
     if args.method == 'base':
-        pass
+        torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, '_' + str(epoch) + '.pt'))
     
     elif args.method == 'coop':
-        torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, str(epoch) + '.pt'))
+        torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, '_' + str(epoch) + '.pt'))
 
     elif args.method == 'cocoop':
-        assert False, "Not Implemented"
+        torch.save(model.state_dict(), os.path.join(args.checkpoint_dir, '_' + str(epoch) + '.pt'))
 
     else:
         assert False, "Not Implemented"
@@ -37,7 +37,8 @@ def make_classification_strings(args):
         classification_strings = ['X ' * args.n_ctx + class_name for class_name in class_names]
 
     elif args.method == 'cocoop':
-        assert False, "Not Implemented: cocoop in utils/__init__.py"
+        class_names = ['english', 'odiya']
+        classification_strings = ['X ' * args.n_ctx + class_name for class_name in class_names]
 
     else:
         assert False, f"Not implemented: the method '{args.method}' is not yet implemented in utils.py"
@@ -53,7 +54,7 @@ def make_optimizer(args, model):
         optimizer = torch.optim.Adam([model.trainable_param], lr=args.lr, betas=(0.9, 0.98), eps=1e-6, weight_decay=0.2) # taken from a paper.
 
     elif args.method == 'cocoop':
-        assert False, "Not Implemented: cocoop in utils/__init__.py"
+        optimizer = torch.optim.Adam([model.trainable_param] + list(model.meta_net.parameters()), lr=args.lr, betas=(0.9, 0.98), eps=1e-6, weight_decay=0.2)
 
     else:
         assert False, f"Not implemented: the method '{args.method}' is not yet implemented in utils.py"

--- a/utils/evaluation_methods.py
+++ b/utils/evaluation_methods.py
@@ -15,7 +15,10 @@ def accuracy_clip_base(args, model, preprocess, loader, classification_strings):
           image_features = image_features / image_features.norm(dim=-1, keepdim=True)
 
           # get text features
-          class_features = model.encode_text(clip.tokenize(classification_strings).to(args.device))
+          class_features = model.encode_text(texts)
+          class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+          # compute similarity
           similarity = (100 * image_features @ class_features.T).softmax(dim=-1)
           predictions = torch.argmax(similarity, dim=1)
           total += similarity.shape[0]
@@ -26,20 +29,48 @@ def accuracy_clip_base(args, model, preprocess, loader, classification_strings):
 def accuracy_clip_coop(args, model, preprocess, loader, classification_strings):
     correct, total = 0, 0
     with torch.no_grad():
-      for batch in tqdm(loader):
-          images, labels = batch
-          images, labels = images.to(args.device), labels.to(args.device)
-          texts = clip.tokenize(classification_strings).to(args.device)
+        for batch in tqdm(loader):
+            images, labels = batch
+            images, labels = images.to(args.device), labels.to(args.device)
+            texts = clip.tokenize(classification_strings).to(args.device)
 
-          # get image features
-          image_features = model.encode_image(images)
-          image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+            # get image features
+            image_features = model.encode_image(images)
+            image_features = image_features / image_features.norm(dim=-1, keepdim=True)
 
-          # get text features
-          class_features = model.encode_text_coop(clip.tokenize(classification_strings).to(args.device)) # using the modded text encoder
-          similarity = (100 * image_features @ class_features.T).softmax(dim=-1)
-          predictions = torch.argmax(similarity, dim=1)
-          total += similarity.shape[0]
-          correct += int(sum(predictions == labels))
+            # get text features
+            class_features = model.encode_text_coop(texts) # using the modded text encoder
+            class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+            # compute similarity
+            similarity = (100 * image_features @ class_features.T).softmax(dim=-1)
+            predictions = torch.argmax(similarity, dim=1)
+            total += similarity.shape[0]
+            correct += int(sum(predictions == labels))
+
+    return correct / total
+
+def accuracy_clip_cocoop(args, model, preprocess, loader, classification_strings):
+    correct, total = 0, 0
+    with torch.no_grad():
+        for batch in tqdm(loader):
+            images, labels = batch
+            images, labels = images.to(args.device), labels.to(args.device)
+            texts = clip.tokenize(classification_strings).to(args.device)
+
+            # get image features
+            image_features = model.encode_image(images)
+            image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+
+            # get text features
+            class_features = model.encode_text_cocoop(texts, image_features) # using the modded text encoder
+            class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+            # compute similarity
+            image_features = image_features.unsqueeze(2)
+            similarity = torch.bmm(class_features, 100 * image_features).softmax(dim=-1)
+            predictions = torch.argmax(similarity, dim=1)
+            total += similarity.shape[0]
+            correct += int(sum(predictions == labels))
 
     return correct / total

--- a/utils/training_methods.py
+++ b/utils/training_methods.py
@@ -37,6 +37,9 @@ def train_clip_base(args, model, preprocess, loader, optimizer, criterion, class
 
         # get text features
         class_features = model.encode_text(texts)
+        class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+        # compute similarity
         similarity = (100 * image_features @ class_features.T).softmax(dim=-1)
         predictions = torch.argmax(similarity, dim=1)
 
@@ -65,8 +68,42 @@ def train_clip_coop(args, model, preprocess, loader, optimizer, criterion, class
 
         # get text features
         class_features = model.encode_text_coop(texts) # using the modded text encoder
+        class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+        # compute similarity
         similarity = (100 * image_features @ class_features.T).softmax(dim=-1)
         predictions = torch.argmax(similarity, dim=1)
+
+        loss = nn.CrossEntropyLoss()(similarity, labels)
+        loss.backward()
+        losses.append(loss.item())
+        if args.device == "cpu":
+            optimizer.step()
+        else :
+            convert_models_to_fp32(model)
+            optimizer.step()
+            convert_back_to_fp16(args, model)
+    return losses
+
+def train_clip_cocoop(args, model, preprocess, loader, optimizer, criterion, classification_strings):
+    losses = []
+    for batch in tqdm(loader):
+        optimizer.zero_grad()
+        images, labels = batch
+        images, labels = images.to(args.device), labels.to(args.device)
+        texts = clip.tokenize(classification_strings).to(args.device)
+
+        # get image features
+        image_features = model.encode_image(images)
+        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+
+        # get text features
+        class_features = model.encode_text_cocoop(texts, image_features) # using the modded text encoder
+        class_features = class_features / class_features.norm(dim=-1, keepdim=True)
+
+        # compute similarity
+        image_features = image_features.unsqueeze(2)
+        similarity = torch.bmm(class_features, 100 * image_features).softmax(dim=-1)
 
         loss = nn.CrossEntropyLoss()(similarity, labels)
         loss.backward()


### PR DESCRIPTION
Added the CoCoOp approach for more generalisable fine-tuning for CLIP, from the paper [Conditional Prompt Learning for Vision-Language Models](https://arxiv.org/abs/2203.05557).

The approach conditions a meta-net to produce additional context vectors as input to the text encoder.

Usage requires atleast 15-20 GBs of GPU RAM for finetuning on a batch size of 1.

![image](https://github.com/shrivastava95/clip-ocr/assets/75275497/f95df02a-5435-4e34-ad7f-892fe167efd6)
